### PR TITLE
Making the "usage" function static.

### DIFF
--- a/system/expressionengine/third_party/gwcode_fileinfo/pi.gwcode_fileinfo.php
+++ b/system/expressionengine/third_party/gwcode_fileinfo/pi.gwcode_fileinfo.php
@@ -257,7 +257,7 @@ class Gwcode_fileinfo {
 	/**
 	 * Describes how the plugin is used.
 	 */
-	public function usage() {
+	public static function usage() {
 		ob_start();
 ?>
 ###### 1. Get information about a single file


### PR DESCRIPTION
Using this plug-in on PHP 5.5 with EE 2.9 throws following warning:

A PHP Error was encountered
Severity: 8192
Message: Non-static method Gwcode_fileinfo::usage() should not be called statically, assuming $this from incompatible context
Filename: gwcode_fileinfo/pi.gwcode_fileinfo.php
Line Number: 19

This is mostly because the usage() function is being called statically at line #19. Adding "static" keyword to the function at line #260 fixes this problem. Hopefully you can merge this into the main branch and benefit future users. Thanks.
